### PR TITLE
Новый абстрактный класс удаления

### DIFF
--- a/rcore-domain/rcore-domain-commons/src/main/java/com/rcore/domain/commons/usecase/AbstractExtendedDeleteUseCase.java
+++ b/rcore-domain/rcore-domain-commons/src/main/java/com/rcore/domain/commons/usecase/AbstractExtendedDeleteUseCase.java
@@ -1,0 +1,61 @@
+package com.rcore.domain.commons.usecase;
+
+import com.rcore.domain.commons.entity.BaseEntity;
+import com.rcore.domain.commons.port.CRUDRepository;
+import com.rcore.domain.commons.usecase.model.IdInputValues;
+import lombok.Value;
+
+import java.util.Optional;
+
+/**
+ * Абстрактный класс для удаляющего use case.
+ * С возможностью переопределить метод который запускается перед и после удаления.
+ *
+ * @param <Id>         - Тип идентификатора сущности
+ * @param <Entity>     - Тип сущности
+ * @param <Repository> - удаляющий репозиторий
+ */
+public abstract class AbstractExtendedDeleteUseCase<Id, Entity extends BaseEntity<Id>, Repository extends CRUDRepository<Id, Entity, ?>> extends UseCase<IdInputValues<Id>, AbstractExtendedDeleteUseCase.OutputValues> {
+    protected final Repository repository;
+
+    public AbstractExtendedDeleteUseCase(Repository repository) {
+        this.repository = repository;
+    }
+
+    /**
+     * Вызывается перед удалением. Можно переопределить.
+     *
+     * @return если вернуть false, то удаление не произойдёт
+     */
+    public boolean before(Entity entity) {
+        return true;
+    }
+
+    @Override
+    public OutputValues execute(IdInputValues<Id> idInputValues) {
+        boolean idDeleted = false;
+        Optional<Entity> optional = repository.findById(idInputValues.getId());
+        if (optional.isEmpty())
+            return OutputValues.of(false);
+
+        if (before(optional.get()))
+            idDeleted = repository.delete(idInputValues.getId());
+
+        if (idDeleted)
+            after(optional.get());
+
+        return OutputValues.of(idDeleted);
+    }
+
+    /**
+     * Вызывается после удаления. Можно переопределить.
+     */
+    public void after(Entity entity) {
+    }
+
+
+    @Value(staticConstructor = "of")
+    public static class OutputValues implements UseCase.OutputValues {
+        Boolean result;
+    }
+}


### PR DESCRIPTION

Абстрактный класс `AbstractExtendedDeleteUseCase` реализующий механизм стандартного удаления и предоставляющий для
переопределения два метода

- `boolean before(Entity entity)` вызывается перед удалением. Если этот метод вернёт false удаление не произойдёт
- `void after(Entity entity)` вызывается после успешного удаления. Можно использовать для отправки событий.

Класс требует указать тип `Id`, тип `Entity` удаления и полный CRUD репозиторий
